### PR TITLE
handle errors, like ECONNRESET, on the socket

### DIFF
--- a/lib/sticky-session.js
+++ b/lib/sticky-session.js
@@ -50,9 +50,9 @@ module.exports = function sticky(num, callback) {
           ipHash = hash((c.remoteAddress || '').split(/\./g), seed);
 
       // handle errors like ECONNRESET on the socket
-	  c.on('error', function (err) {
-	    console.error('sticky-session: socket error', err);
-	  });
+      c.on('error', function (err) {
+        console.error('sticky-session: socket error', err);
+      });
 
       // Pass connection to worker
       worker = workers[ipHash % workers.length];

--- a/lib/sticky-session.js
+++ b/lib/sticky-session.js
@@ -49,6 +49,11 @@ module.exports = function sticky(num, callback) {
       var worker,
           ipHash = hash((c.remoteAddress || '').split(/\./g), seed);
 
+      // handle errors like ECONNRESET on the socket
+	  c.on('error', function (err) {
+	    console.error('sticky-session: socket error', err);
+	  });
+
       // Pass connection to worker
       worker = workers[ipHash % workers.length];
       worker.send('sticky-session:connection', c);


### PR DESCRIPTION
the socket, that was passed on to the worker, occasionally threw errors (like ECONNRESET), so at least handle&log the error