### PR TITLE
Fixes issue with TCP connection establishment

### DIFF
--- a/lib/sticky-session.js
+++ b/lib/sticky-session.js
@@ -44,7 +44,7 @@ module.exports = function sticky(num, callback) {
     }
 
     var seed = ~~(Math.random() * 1e9);
-    server = net.createServer(function(c) {
+    server = net.createServer({pauseOnConnect: true}, function(c) {
       // Get int31 hash of ip
       var worker,
           ipHash = hash((c.remoteAddress || '').split(/\./g), seed);


### PR DESCRIPTION
https://github.com/joyent/node/issues/7784

Bug: Some TCP sockets passed to workers are never fully established causing connection timeouts.

Cause: The master process begins consuming TCP establishment data from the socket before passing the socket to the child process.  Neither the master process or the child process can finish the establishment process.

Fix: Set pauseOnConnect = true on the TCP server so that the master process doesn't start processing data on sockets before passing them to child processes.  This feature was added to node 12 to fix exactly this bug.