### PR TITLE
Bump node version to 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ A simple performant way to use [socket.io](http://socket.io/) with a
 npm install sticky-session
 ```
 
+##### Note about `node` version
+
+`sticky-session` requires `node` to be version at least `0.12.0` because it relies on the `net.createServer`'s [`pauseOnConnect` flag](https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener).
+
 ## Usage
 
 ```javascript
@@ -38,6 +42,8 @@ different workers, which will break handshake protocol.
 Sticky-sessions module is balancing requests using their IP address. Thus
 client will always connect to same worker server, and socket.io will work as
 expected, but on multiple processes!
+
+A deeper, step-by-step explanation on how this works can be found in [`elad/node-cluster-socket.io`](https://github.com/elad/node-cluster-socket.io)
 
 #### LICENSE
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ A simple performant way to use [socket.io](http://socket.io/) with a
 npm install sticky-session
 ```
 
-##### Note about `node` version
-
-`sticky-session` requires `node` to be at least `0.12.0` because it relies on
-`net.createServer`'s [`pauseOnConnect` flag](https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener).
-
 ## Usage
 
 ```javascript
@@ -44,7 +39,14 @@ Sticky-sessions module is balancing requests using their IP address. Thus
 client will always connect to same worker server, and socket.io will work as
 expected, but on multiple processes!
 
-A deeper, step-by-step explanation on how this works can be found in [`elad/node-cluster-socket.io`](https://github.com/elad/node-cluster-socket.io)
+#### Note about `node` version
+
+`sticky-session` requires `node` to be at least `0.12.0` because it relies on
+`net.createServer`'s [`pauseOnConnect` flag](https://nodejs.org/api/net.html#
+net_net_createserver_options_connectionlistener).
+
+A deeper, step-by-step explanation on how this works can be found in
+[`elad/node-cluster-socket.io`](https://github.com/elad/node-cluster-socket.io)
 
 #### LICENSE
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ npm install sticky-session
 
 ##### Note about `node` version
 
-`sticky-session` requires `node` to be version at least `0.12.0` because it relies on the `net.createServer`'s [`pauseOnConnect` flag](https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener).
+`sticky-session` requires `node` to be at least `0.12.0` because it relies on
+`net.createServer`'s [`pauseOnConnect` flag](https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener).
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ip": "^1.0.0"
   },
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 0.12.0"
   },
   "devDependencies": {
     "debug": "^2.2.0",


### PR DESCRIPTION
The `>= 0.6.0` in `package.json` no longer applies since `sticky-session` relies on the `pauseOnConnect` flag released with `node` version `0.12.0`

I also updated `README.md` with a warning notice and a link to [`elad/node-cluster-socket.io`](https://github.com/elad/node-cluster-socket.io) where there's a complete step-by-step explanation on how this all works.