### PR TITLE
Clarify worker code vs master code and how to get worker id

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ npm install sticky-session
 ## Usage
 
 ```javascript
+var cluster = require('cluster'); // Only required if you want the worker id
 var sticky = require('sticky-session');
 
 var server = require('http').createServer(function(req, res) {
-  res.end('worker: ' + process.env.NODE_WORKER_ID);
+  res.end('worker: ' + cluster.worker.id);
 });
 
 if (!sticky.listen(server, 3000)) {
@@ -23,7 +24,7 @@ if (!sticky.listen(server, 3000)) {
     console.log('server started on 3000 port');
   });
 } else {
-  // Master code
+  // Worker code
 }
 ```
 Simple


### PR DESCRIPTION
Hi,

Thanks for this.  I found this while attempting to implement the [redis adapter for socket.io](http://socket.io/docs/using-multiple-nodes/#using-node.js-cluster), but while attempting to use this package for the first time, I ran into two problems.

1. The current `README.md` file lists both the `if` and `else` blocks of the `if (!sticky.listen(server, 3000)) {` statement as `// Master code`.
    * Looking at the [`listen`](https://github.com/indutny/sticky-session/blob/master/lib/sticky/api.js#L14) method its clear to see that this returns `false` when it is the parent, and `true` when it is a worker, but it'd be nice to clarify this in the docs.
2. `process.env.NODE_WORKER_ID` was not available.
    * Issue #35 seems to report this as well.  The suggestion there was to use `process.env.NODE_UNIQUE_ID`, but that did not work for me.
    * Requiring `cluster` however, and using `cluster.worker.id` worked here.
        * Tested on `v0.12.7` and `v4.2.2`

If I've mis-interpreted anything, let me know, but figured I'd save the next developer to come this way some trouble.