### PR TITLE
Added Reverse Proxy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm install sticky-session
 
 ## Usage
 
+##### Simple #####
+
 ```javascript
 var cluster = require('cluster'); // Only required if you want the worker id
 var sticky = require('sticky-session');
@@ -27,7 +29,38 @@ if (!sticky.listen(server, 3000)) {
   // Worker code
 }
 ```
-Simple
+
+
+##### Reverse Proxy Support #####
+
+By default the Node `net` library only provides `remoteAddress`. This is problematic when your node app lives behind a reverse proxy. Below is an example of using sticky-session to load balance based on an arbitrary http header.
+
+**Warning:** The reverse proxy feature parses the first incoming http packet before load balancing it (in order to read the header), this may lead to performance issues.
+
+```javascript
+var cluster = require('cluster'); // Only required if you want the worker id
+var sticky = require('sticky-session');
+
+var server = require('http').createServer(function(req, res) {
+  res.end('worker: ' + cluster.worker.id);
+});
+
+let isChild = sticky.listen(server, 3000, {
+  workers: 8,
+  proxyHeader: 'x-forwarded-for'//header to read for IP
+});
+
+if (!isChild) {
+  // Master code
+  server.once('listening', function() {
+    console.log('server started on 3000 port');
+  });
+} else {
+  // Worker code
+}
+```
+
+
 
 ## Reasoning
 

--- a/lib/sticky/api.js
+++ b/lib/sticky/api.js
@@ -12,9 +12,9 @@ function listen(server, port, options) {
     options = {};
 
   if (cluster.isMaster) {
-    var workerCount = options.workers || os.cpus().length;
+    options.workers = options.workers || os.cpus().length;
 
-    var master = new Master(workerCount);
+    var master = new Master(options);
     master.listen(port);
     master.once('listening', function() {
       server.emit('listening');
@@ -23,12 +23,19 @@ function listen(server, port, options) {
   }
 
   process.on('message', function(msg, socket) {
-    if (msg !== 'sticky:balance' || !socket)
+    if (!msg.length || msg[0] !== 'sticky:balance' || !socket)
       return;
 
     debug('incoming socket');
+
+    // reappend the buffer
+    if (msg[1]) {
+      socket.unshift(new Buffer(msg[1], 'base64'));
+    }
+
     server.emit('connection', socket);
   });
+
   return true;
 }
 exports.listen = listen;

--- a/lib/sticky/master.js
+++ b/lib/sticky/master.js
@@ -4,20 +4,33 @@ var cluster = require('cluster');
 var util = require('util');
 var net = require('net');
 var ip = require('ip');
+var common = require('_http_common');
+var parsers = common.parsers;
+var HTTPParser = process.binding('http_parser').HTTPParser;
+
 
 var debug = require('debug')('sticky:master');
 
-function Master(workerCount) {
+function Master(options) {
+  debug('master options=%j', options);
+
+  var balanceFunc;
+  if(options.proxyHeader)
+    balanceFunc = this.balanceProxyAddress;
+  else
+    balanceFunc = this.balanceRemoteAddress;
+
   net.Server.call(this, {
     pauseOnConnect: true
-  }, this.balance);
+  }, balanceFunc);
 
+  this.options = options || {};
   this.seed = (Math.random() * 0xffffffff) | 0;
   this.workers = [];
 
   debug('master seed=%d', this.seed);
 
-  for (var i = 0; i < workerCount; i++)
+  for (var i = 0; i < options.workers; i++)
     this.spawnWorker();
 
   this.once('listening', function() {
@@ -68,10 +81,38 @@ Master.prototype.respawn = function respawn(worker) {
   this.spawnWorker();
 };
 
-Master.prototype.balance = function balance(socket) {
+Master.prototype.balanceRemoteAddress = function balance(socket) {
   var addr = ip.toBuffer(socket.remoteAddress || '127.0.0.1');
   var hash = this.hash(addr);
 
   debug('balacing connection %j', addr);
-  this.workers[hash % this.workers.length].send('sticky:balance', socket);
+  this.workers[hash % this.workers.length].send(['sticky:balance'], socket);
+};
+
+Master.prototype.balanceProxyAddress = function balance(socket) {
+  var self = this;
+  debug('incoming proxy');
+  socket.resume();
+  socket.once('data', function (buffer) {
+      var parser = parsers.alloc();
+      parser.reinitialize(HTTPParser.REQUEST);
+      parser.onIncoming = function (req) {
+
+          //default to remoteAddress, but check for
+          //existence of proxyHeader
+          var address = socket.remoteAddress || '';
+
+          if (self.options.proxyHeader && req.headers[self.options.proxyHeader]) {
+              address = req.headers[self.options.proxyHeader];
+          }
+          debug('Proxy Address %j', address);
+          var hash = self.hash(ip.toBuffer(address));
+
+          // Pass connection to worker
+          // Pack the request with the message
+          self.workers[hash % self.workers.length].send(['sticky:balance', buffer.toString('base64')], socket);
+      };
+      parser.execute(buffer, 0, buffer.length);
+      parser.finish();
+  });
 };

--- a/test/test-proxy.js
+++ b/test/test-proxy.js
@@ -1,0 +1,66 @@
+var sticky = require('../');
+var assert = require('assert');
+var http = require('http');
+
+var PORT = 13845;
+
+var server = http.createServer(function(req, res) {
+  res.writeHead(200, {
+    'X-Sticky': process.pid
+  });
+  res.end('hello world');
+});
+
+if (sticky.listen(server, PORT, { proxyHeader: 'x-forwarded-for', workers: 8 }))
+  return;
+
+// Master
+var waiting = 100;
+  batches = 2;
+
+var returned = [];
+
+for (var i = 0; i < waiting/batches; i++) {
+  var request = http.request({
+    method: 'GET',
+    host: '127.0.0.1',
+    headers:{
+      'x-forwarded-for': '1.1.1.1'
+    },
+    port: PORT
+  }, done);
+  request.write('');
+  request.end();
+}
+
+for (var i = 0; i < waiting/batches; i++) {
+  var request = http.request({
+    method: 'GET',
+    host: '127.0.0.1',
+    headers:{
+      'x-forwarded-for': '255.255.255.255'
+    },
+    port: PORT
+  }, done);
+  request.write('');
+  request.end();
+}
+
+
+function done(res) {
+  assert(res.headers['x-sticky']);
+  if(!inArray(returned, res.headers['x-sticky']))
+    returned.push(res.headers['x-sticky']);
+  res.resume();
+  if (--waiting === 0){
+    assert(returned.length === 2);
+    process.exit(0);
+  }
+}
+
+function inArray(arr, comparer) {
+    for(var i=0; i < arr.length; i++) {
+        if(arr[i] === comparer) return true;
+    }
+    return false;
+};


### PR DESCRIPTION
This pull request is a proposed solution for reverse proxy support. It leaves all existing functionality in place with no effect whatsoever if you are not using the new proposed option: `proxyHeader`.

This fixes issue #6  and #15 and it is heavily based on PR #20.
### Logic

The basic logic is to parse the first packet on an incoming connection, read the IP header information, and load balance based on the header IP. The read packet is included in the load-balancing IPC message and is unshift'ed back onto the socket. 

I included a basic proxy test and testing with [websocket bench](https://github.com/M6Web/websocket-bench) seems to indicate no major issues.

There were also some minor changes regarding the options object and I added some basic logic to support different types of balancing functions.
### Example Usage

``` javascript
var cluster = require('cluster'); // Only required if you want the worker id
var sticky = require('sticky-session');

var server = require('http').createServer(function(req, res) {
  res.end('worker: ' + cluster.worker.id);
});

let isChild = sticky.listen(server, 3000, {
  workers: 8,
  proxyHeader: 'x-forwarded-for'//header to read for IP
});

if (!isChild) {
  // Master code
  server.once('listening', function() {
    console.log('server started on 3000 port');
  });
} else {
  // Worker code
}
```
