### PR TITLE
Support host definiton within options

### DIFF
--- a/lib/sticky/api.js
+++ b/lib/sticky/api.js
@@ -15,7 +15,7 @@ function listen(server, port, options) {
     var workerCount = options.workers || os.cpus().length;
 
     var master = new Master(workerCount, options.env);
-    master.listen(port);
+    master.listen(port, options.host);
     master.once('listening', function() {
       server.emit('listening');
     });


### PR DESCRIPTION
While net.Server supports defining a host, Master did not. Now it does.
