### PR TITLE
Hosts & Accessible Server Instance (and tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ var server = require('http').createServer(function(req, res) {
   res.end('worker: ' + cluster.worker.id);
 });
 
-if (!sticky.listen(server, 3000)) {
+var options = {env:{"foo":"Some Environment Variables (optional)"}};
+
+if (!sticky.listen(server, 3000, options)) {
   // Master code
   server.once('listening', function() {
     console.log('server started on 3000 port');
@@ -29,6 +31,30 @@ if (!sticky.listen(server, 3000)) {
 ```
 Simple
 
+## Options
+The options object is optional and can be passed in as a third parameter to sticky.listen.
+### env
+Object: An object containing key/value environment variables that each worker will receive.
+### host
+String: A string value that the server will bind to as its host.
+### workers
+Integer: The number of workers to bring up. Defaults to the number of available cores.
+### returnInstance
+Boolean: Affects what is returned by the sticky.listen function. Defaults to `false`.
+When false: return `false` for tha master cluster process, and `true` to workers.
+When true: return the server instance to the master cluster process, and `false` to workers.
+```
+var serverInstance = sticky.listen(server, 3000, {returnInstance: true});
+if(serverInstance !== false){
+    //Master code
+    server.once('listening', function() {
+        var address = serverInstance.address();
+        console.log("Server listening on " + address.address + ":" + address.port");
+    });
+} else {
+    //Worker code
+}
+```
 ## Reasoning
 
 Socket.io is doing multiple requests to perform handshake and establish

--- a/lib/sticky/api.js
+++ b/lib/sticky/api.js
@@ -19,7 +19,7 @@ function listen(server, port, options) {
     master.once('listening', function() {
       server.emit('listening');
     });
-    return false;
+    return options.returnInstance === true ? master : false;
   }
 
   // Override close callback to gracefully close server
@@ -39,6 +39,6 @@ function listen(server, port, options) {
     socket.server = server;
     server.emit('connection', socket);
   });
-  return true;
+  return options.returnInstance !== true;
 }
 exports.listen = listen;

--- a/lib/sticky/api.js
+++ b/lib/sticky/api.js
@@ -15,7 +15,7 @@ function listen(server, port, options) {
     var workerCount = options.workers || os.cpus().length;
 
     var master = new Master(workerCount, options.env);
-    master.listen(port);
+    master.listen(port, options.host);
     master.once('listening', function() {
       server.emit('listening');
     });

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+for f in ./test/*.js
+do
+	echo "Running test $f"
+	node $f
+done

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,0 @@
-for f in ./test/*.js
-do
-	echo "Running test $f"
-	node $f
-done

--- a/test/100-connections-test.js
+++ b/test/100-connections-test.js
@@ -5,6 +5,11 @@ var http = require('http');
 
 var PORT = 13845;
 
+setTimeout(function(){
+  console.error("Test time exceeded");
+  process.exit(1);
+}, 5000);
+
 var server = http.createServer(function(req, res) {
   res.writeHead(200, {
     'X-Sticky': process.pid

--- a/test/fork-options-test.js
+++ b/test/fork-options-test.js
@@ -6,17 +6,25 @@ var http = require('http');
 
 var PORT = 13845;
 
-var server = http.createServer(function(req, res) {
-  res.end('hello world');
+setTimeout(function(){
+    console.error("Test time exceeded");
+    process.exit(1);
+}, 5000);
+
+var server = http.createServer(function (req, res) {
+    res.end('hello world');
 });
 
-if (sticky.listen(server, PORT, { workers: 1, env: { ohai: 23 } })) {
-  process.send(process.env.ohai);
-  return;
-}
-
+if (sticky.listen(server, PORT, {workers: 1, env: {ohai: 23}})) {
+    setTimeout(function () {
+        process.send(process.env.ohai);
+    }, 500);
+} else {
 // Master
-cluster.workers[Object.keys(cluster.workers)[0]].on('message', function(msg) {
-  assert.equal(msg, '23');
-  process.exit(0);
-});
+    setTimeout(function () {
+        cluster.workers[Object.keys(cluster.workers)[0]].on('message', function (msg) {
+            assert.equal(msg, '23');
+            process.exit(0);
+        });
+    }, 250);
+}

--- a/test/graceful-close-test.js
+++ b/test/graceful-close-test.js
@@ -5,6 +5,11 @@ var http = require('http');
 
 var PORT = 13845;
 
+setTimeout(function(){
+  console.error("Test time exceeded");
+  process.exit(1);
+}, 5000);
+
 var done = true;
 
 var server = http.createServer(function(req, res) {

--- a/test/host-test.js
+++ b/test/host-test.js
@@ -1,0 +1,35 @@
+var sticky = require('../');
+
+var assert = require('assert');
+var cluster = require('cluster');
+var http = require('http');
+
+var PORT = 13845;
+
+setTimeout(function(){
+    console.error("Test time exceeded");
+    process.exit(1);
+}, 5000);
+var completed = 0;
+var runHost = function(host, expectation){
+
+    var server = http.createServer(function (req, res) {
+        res.end('hello world');
+    });
+
+    var serverInstance = sticky.listen(server, PORT, {returnInstance: true, host: host, workers: 1, env: {ohai: 23}});
+    if(serverInstance === true){
+        process.exit(0);
+    }
+
+    server.once('listening', function() {
+        assert.equal(serverInstance.address().port, PORT);
+        assert.equal(serverInstance.address().address, expectation);
+        completed++;
+        if(completed == 2){
+            process.exit(0);
+        }
+    });
+};
+runHost(undefined, "::");
+runHost("localhost", "127.0.0.1");

--- a/test/master-object-test.js
+++ b/test/master-object-test.js
@@ -1,0 +1,26 @@
+var sticky = require('../');
+
+var assert = require('assert');
+var cluster = require('cluster');
+var http = require('http');
+
+var PORT = 13845;
+
+setTimeout(function(){
+    console.error("Test time exceeded");
+    process.exit(1);
+}, 5000);
+
+var server = http.createServer(function (req, res) {
+    res.end('hello world');
+});
+
+var serverInstance = sticky.listen(server, PORT, {returnInstance: true, workers: 1, env: {ohai: 23}});
+if(serverInstance === false){
+    process.exit(0);
+}
+
+server.once('listening', function() {
+    assert.equal(serverInstance.address().port, PORT);
+    process.exit(0);
+});


### PR DESCRIPTION
Feature: Host can be set in options.
Feature: The server instance, with .address() function etc is passed back on master(old: master=false worker=true, new: master=serverInstance, worker=false) - this only happens if you set options.returnInstance to true, otherwise it is 'classis style'.
Existing tests have been updated to manage async issues.
2 new tests (for the 2 new features) have been added.
